### PR TITLE
Fix typo in test_unitree_sdk2.py

### DIFF
--- a/simulate_python/test/test_unitree_sdk2.py
+++ b/simulate_python/test/test_unitree_sdk2.py
@@ -21,7 +21,7 @@ def LowStateHandler(msg: LowState_):
 
 
 if __name__ == "__main__":
-    ChannelFactortyInitialize(1, "lo")
+    ChannelFactoryInitialize(1, "lo")
     hight_state_suber = ChannelSubscriber("rt/sportmodestate", SportModeState_)
     low_state_suber = ChannelSubscriber("rt/lowstate", LowState_)
 


### PR DESCRIPTION
Fix extra 't' typo in ChannelFactoryInitialize(1, "lo")