### PR TITLE
Fix undefined behavior on joystick

### DIFF
--- a/simulate/src/joystick/jstest.cc
+++ b/simulate/src/joystick/jstest.cc
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <map>
 #include "joystick.h"
+#include <stdint.h>
 
 #define GAMEPAD_TYPE 1 // 1: XBOX, 0: SWITCH
 #define MAX_AXES_VALUE 32768

--- a/simulate/src/unitree_sdk2_bridge/unitree_sdk2_bridge.h
+++ b/simulate/src/unitree_sdk2_bridge/unitree_sdk2_bridge.h
@@ -133,7 +133,7 @@ public:
     xRockerBtnDataStruct wireless_remote_ = {};
 
     JoystickId js_id_;
-    Joystick *js_;
+    Joystick *js_ = 0;
     int max_value_ = (1 << 15); // 16 bits joystick
 
     mjData *mj_data_;


### PR DESCRIPTION
This was causing crashes on Asahi Ubuntu running on MBP M1, after these fixes it works without issue