### PR TITLE
Include stdint.h to fix the uint8_t and uint16_t type missing error

### DIFF
--- a/simulate/src/joystick/jstest.cc
+++ b/simulate/src/joystick/jstest.cc
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <unistd.h>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Fix the issue: https://github.com/unitreerobotics/unitree_mujoco/issues/50

During unitree_mujoco installation:
```
cd unitree_mujoco/simulate
mkdir build && cd build
cmake ..
make -j4
``` 

The make command failed with the following errors:
```
/home/unitree/unitree_mujoco/simulate/src/joystick/jstest.cc:30:5: error: ‘uint8_t’ does not name a type
   30 |     uint8_t left : 1;
      |     ^~~~~~~
/home/unitree/unitree_mujoco/simulate/src/joystick/jstest.cc:30:5: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/unitree/unitree_mujoco/simulate/src/joystick/jstest.cc:32:3: error: ‘uint16_t’ does not name a type
   32 |   uint16_t value;
      |   ^~~~~~~~
```

This PR update `simulate/src/joystick/jstest.cc` to add the missing header include.

Please review, thank you.
