### PR TITLE
修复 Python 仿真控制更新时序：按仿真步重算关节控制量

### DIFF
--- a/simulate_python/unitree_mujoco.py
+++ b/simulate_python/unitree_mujoco.py
@@ -51,6 +51,9 @@ def SimulationThread():
 
         locker.acquire()
 
+        # Update control torques from latest command
+        unitree.UpdateControl()
+
         if config.ENABLE_ELASTIC_BAND:
             if elastic_band.enable:
                 mj_data.xfrc_applied[band_attached_link, :3] = elastic_band.Advance(

--- a/simulate_python/unitree_sdk2py_bridge.py
+++ b/simulate_python/unitree_sdk2py_bridge.py
@@ -88,6 +88,9 @@ class UnitreeSdk2Bridge:
         self.low_cmd_suber = ChannelSubscriber(TOPIC_LOWCMD, LowCmd_)
         self.low_cmd_suber.Init(self.LowCmdHandler, 10)
 
+        # Cache latest motor commands (updated by LowCmdHandler)
+        self.low_cmd_latest = None
+
         # joystick
         self.key_map = {
             "R1": 0,
@@ -109,18 +112,30 @@ class UnitreeSdk2Bridge:
         }
 
     def LowCmdHandler(self, msg: LowCmd_):
-        if self.mj_data != None:
-            for i in range(self.num_motor):
-                self.mj_data.ctrl[i] = (
-                    msg.motor_cmd[i].tau
-                    + msg.motor_cmd[i].kp
-                    * (msg.motor_cmd[i].q - self.mj_data.sensordata[i])
-                    + msg.motor_cmd[i].kd
-                    * (
-                        msg.motor_cmd[i].dq
-                        - self.mj_data.sensordata[i + self.num_motor]
-                    )
+        """Cache the latest low command. Control update happens in UpdateControl()."""
+        self.low_cmd_latest = msg
+
+    def UpdateControl(self):
+        """
+        Recompute motor control torques on every simulation step.
+        This is called from the simulation thread before mj_step().
+        τ = tau_cmd + kp*(q_des-q_act) + kd*(dq_des-dq_act)
+        """
+        if self.mj_data is None or self.low_cmd_latest is None:
+            return
+        
+        msg = self.low_cmd_latest
+        for i in range(self.num_motor):
+            self.mj_data.ctrl[i] = (
+                msg.motor_cmd[i].tau
+                + msg.motor_cmd[i].kp
+                * (msg.motor_cmd[i].q - self.mj_data.sensordata[i])
+                + msg.motor_cmd[i].kd
+                * (
+                    msg.motor_cmd[i].dq
+                    - self.mj_data.sensordata[i + self.num_motor]
                 )
+            )
 
     def PublishLowState(self):
         if self.mj_data != None:


### PR DESCRIPTION
## 问题
在 Python 仿真中，关节控制量此前仅在接收到新 LowCmd 回调时计算一次。  
当控制端发送固定目标值时，机器人状态（关节位置/速度）仍在持续变化，但控制量未在每个仿真步同步更新，导致控制输出与当前状态不一致。

## 解决方案
将控制流程拆分为“命令缓存 + 按步计算”两阶段：  
1. 回调函数仅缓存最新 LowCmd，不直接依赖回调时机写最终控制量  
2. 在每个仿真步（`mj_step` 前）基于当前状态重算控制量并写入控制数组  